### PR TITLE
fix `abstract_wormhole`, add `@new_plugin`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2015,7 +2015,7 @@ function abstract_wormhole(interp::AbstractInterpreter, ai::ArgInfo, si::StmtInf
     end
     inner_argtypes = argtypes[3:end]
 
-    other_interp = abstract_interpreter(C, interp.world)
+    other_interp = abstract_interpreter(C, get_world_counter(interp))
     tt = argtypes_to_type(inner_argtypes)
     mt = method_table(other_interp)
     match, _ = findsup(tt, mt)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -436,7 +436,7 @@ end
 Call function `f` with arguments `args` within the context of
 a different compiler plugin.
 """
-invoke_within(C::Union{Nothing, Core.Compiler.CompilerPlugin}, f, args...) = Core.Compiler.invoke_within(args...)
+invoke_within(C::Union{Nothing, Core.Compiler.CompilerPlugin}, f, args...) = Core.Compiler.invoke_within(C, f, args...)
 
 
 end

--- a/test/compiler/plugin.jl
+++ b/test/compiler/plugin.jl
@@ -1,5 +1,5 @@
 module PluginTests
-
+using Test 
 const BE = Base.Experimental
 
 BE.@MethodTable(SinCosTable)
@@ -8,7 +8,7 @@ BE.@new_plugin(SinCosPlugin, SinCosTable)
 BE.@overlay SinCosTable sin(x) = cos(x)
 
 @testset "SinToCosPlugin" begin
-    @test CC.invoke_within(SinCosPlugin(), sin, 1.0) == cos(1.0)
+    @test BE.invoke_within(SinCosPlugin(), sin, 1.0) == cos(1.0)
 end
 
 end

--- a/test/compiler/plugin.jl
+++ b/test/compiler/plugin.jl
@@ -1,49 +1,11 @@
 module PluginTests
 
-const CC = Core.Compiler
+const BE = Base.Experimental
 
-struct SinCosPlugin <: CC.CompilerPlugin
-end
+BE.@MethodTable(SinCosTable)
+BE.@new_plugin(SinCosPlugin, SinCosTable)
 
-Base.Experimental.@MethodTable(SinCosTable)
-Base.Experimental.@overlay SinCosTable sin(x) = cos(x)
-
-import Core: MethodInstance, CodeInstance
-import .CC: WorldRange, WorldView
-
-struct SinCosRewriterCache
-    dict::IdDict{MethodInstance,CodeInstance}
-end
-
-struct SinCosRewriter <: CC.AbstractInterpreter
-    interp::CC.NativeInterpreter
-    world::UInt
-    cache::SinCosRewriterCache
-end
-
-let global_cache = SinCosRewriterCache(IdDict{MethodInstance,CodeInstance}())
-    global function SinCosRewriter(
-        world = Base.get_world_counter();
-        interp = CC.NativeInterpreter(world),
-        cache = global_cache)
-        return SinCosRewriter(interp, world, cache)
-    end
-end
-CC.abstract_interpreter(::SinCosPlugin, world) = SinCosRewriter(world)
-
-CC.InferenceParams(interp::SinCosRewriter) = CC.InferenceParams(interp.interp)
-CC.OptimizationParams(interp::SinCosRewriter) = CC.OptimizationParams(interp.interp)
-CC.get_world_counter(interp::SinCosRewriter) = CC.get_world_counter(interp.interp)
-CC.get_inference_cache(interp::SinCosRewriter) = CC.get_inference_cache(interp.interp)
-CC.code_cache(interp::SinCosRewriter) = WorldView(interp.cache, WorldRange(CC.get_world_counter(interp)))
-CC.get(wvc::WorldView{<:SinCosRewriterCache}, mi::MethodInstance, default) = get(wvc.cache.dict, mi, default)
-CC.getindex(wvc::WorldView{<:SinCosRewriterCache}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
-CC.haskey(wvc::WorldView{<:SinCosRewriterCache}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
-function CC.setindex!(wvc::WorldView{<:SinCosRewriterCache}, ci::CodeInstance, mi::MethodInstance)
-    # ccall(:jl_mi_cache_insert, Cvoid, (Any, Any), mi, ci)
-    setindex!(wvc.cache.dict, ci, mi)
-end
-CC.method_table(interp::SinCosRewriter) = CC.OverlayMethodTable(interp.interp.world, SinCosTable)
+BE.@overlay SinCosTable sin(x) = cos(x)
 
 @testset "SinToCosPlugin" begin
     @test CC.invoke_within(SinCosPlugin(), sin, 1.0) == cos(1.0)


### PR DESCRIPTION
I think it's generally better to use `get_world_counter(interp)` instead of `interp.world`. 

I also packaged some stuff for making plugins into Base.Experimental to cut down on verbosity in playing around with this stuff. 